### PR TITLE
SIGABRT handling + more tests

### DIFF
--- a/src/objs/signal_handler/exceptions/abort_requested.cpp
+++ b/src/objs/signal_handler/exceptions/abort_requested.cpp
@@ -1,0 +1,10 @@
+#include "abort_requested.h"
+
+#include <csignal>
+
+using namespace test;
+
+abort_requested::abort_requested() :
+	signal_received(SIGABRT, "abort (core dumped)")
+{}
+

--- a/src/objs/signal_handler/exceptions/abort_requested.h
+++ b/src/objs/signal_handler/exceptions/abort_requested.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "signal_received.h"
+
+namespace test {
+	class abort_requested : public signal_received {
+		public:
+			abort_requested();
+	};
+}

--- a/src/objs/signal_handler/signal_handler.cpp
+++ b/src/objs/signal_handler/signal_handler.cpp
@@ -1,5 +1,7 @@
 #include "signal_handler.h"
 #include "exceptions/segmentation_fault.h"
+#include "exceptions/abort_requested.h"
+#include <functional>
 
 using namespace test;
 using namespace std;
@@ -8,17 +10,26 @@ void sigsegv_handler ([[maybe_unused]] int signal) {
 	throw segmentation_fault();
 }
 
+void sigabrt_handler ([[maybe_unused]] int signal) {
+	throw abort_requested();
+}
+
 void generic_handler(int signal_code) {
 	throw signal_received(signal_code, "received signal "s + to_string(signal_code));
 }
 
 void test::handle_signal (int signal_code) {
+	function<void(int)> signal_handler;
 	switch (signal_code) {
 		case SIGSEGV:
-			signal(SIGSEGV, sigsegv_handler);
+			signal_handler = sigsegv_handler;
+			break;
+		case SIGABRT:
+			signal_handler = sigabrt_handler;
 			break;
 		default:
-			signal(signal_code, generic_handler);
+			signal_handler = generic_handler;
 	}
+	signal(signal_code, *signal_handler.target<void(*)(int)>());
 }
 

--- a/src/objs/tests_manager.cpp
+++ b/src/objs/tests_manager.cpp
@@ -14,6 +14,9 @@ using namespace std;
 tests_manager::tests_manager () :
 	tests_pool(std::thread::hardware_concurrency())
 {
+	test::handle_signal(SIGSEGV);
+	test::handle_signal(SIGABRT);
+
 	observers.emplace_back(new live_terminal);
 	observers.emplace_back(new json_logger(cerr));
 	notify_tests_begun();
@@ -28,8 +31,6 @@ tests_manager::~tests_manager () {
 void tests_manager::queue_test_for_execution (const string &test_case_description, unsigned row_in_terminal, const function<void()>& test) {
 	auto test_future = tests_pool.exec([=]() {
 		string low_level_error_message;
-
-		test::handle_signal(SIGSEGV);
 
 		notify_test_case_execution_begun(test_case_description, row_in_terminal);
 

--- a/tests/low_level_error.cpp
+++ b/tests/low_level_error.cpp
@@ -1,28 +1,54 @@
 #include <test.h>
-#include <thread>
+#include <future>
 #include <chrono>
+#include "signal_handler/exceptions/signal_received.h"
 
 using namespace std;
 using namespace chrono;
 
 tests {
-
 	test_suite("segmentation fault") {
-		test_case ("do something before low level error executes") {
+		test_case ("do something before segmentation fault") {
 			assert(true, ==, true);
 		};
 
-		test_case("raises low level error after 2s") {
+		test_case("segfaults in main thread after 500ms") {
 			int* x = NULL;
-			this_thread::sleep_for(2s);
+			this_thread::sleep_for(500ms);
 			*x = 2;
 			assert(*x, ==, 2);
 		};
 
-		test_case("continue execution normally") {
-			std::this_thread::sleep_for(3s);
+		test_case("segfaults in async method after 750ms") {
+			auto segfault_future = async(launch::async, [&] {
+				int* x = NULL;
+				this_thread::sleep_for(750ms);
+				*x = 2;
+				assert(*x, ==, 2);
+			});
+
+			segfault_future.get();
+		};
+
+		test_case("segfaults in thread after 1s") {
+			bool exception_raised = false;
+			std::thread([&] {
+				try {
+					int* x = NULL;
+					this_thread::sleep_for(1s);
+					*x = 2;
+					assert(*x, ==, 2);
+				} catch (const test::signal_received& e) {
+					exception_raised = true;
+				}
+			}).join();
+
+			assert(exception_raised, ==, true);
+		};
+
+		test_case("shuould continue execution normally after 1500ms") {
+			std::this_thread::sleep_for(1500ms);
 		};
 	}
-
 }
 


### PR DESCRIPTION
The change in signal handling introduced in #12 did improve the problems describe in #3 a lot.

There's still, however, a problem related to how `std::threads` handles exceptions. Since it never rethrows exceptions raised during its execution, the thread never allows the tests manager to capture the exception, even though the signal handler is working for the thread.