### PR TITLE
Fixed setup being executed multiple times

### DIFF
--- a/src/objs/test.h
+++ b/src/objs/test.h
@@ -77,12 +77,12 @@
 	ASSERT_LABEL_NOT_DEFINED(assert_setup_method, "cannot define multiple setups in a single test_suite");\
 	ASSERT_LABEL_DEFINED(assert_test_case_block, "cannot declare setup outside test_suite");\
 	::std::function<fixture_type()> assert_setup_method;\
-	::test::fixture<::std::function<fixture_type()>> assert_fixture;\
+	::std::shared_ptr<::test::fixture<fixture_type>> assert_fixture(new ::test::fixture<fixture_type>);\
 	auto& fixture_label = assert_fixture;\
 	goto ASSERT_GENERATE_LABEL(ASSERT_LABEL_BEGIN_SETUP_BLOCK);\
 	while(true)\
 		if (true) {\
-			assert_fixture = ::test::fixture<::std::function<fixture_type()>>(assert_setup_method);\
+			fixture_label->set_setup(assert_setup_method);\
 			break;\
 		} else\
 			ASSERT_GENERATE_LABEL(ASSERT_LABEL_BEGIN_SETUP_BLOCK):\
@@ -91,15 +91,15 @@
 #define teardown(fixture_label) ;\
 	ASSERT_LABEL_NOT_DEFINED(assert_teardown_method, "cannot define multiple teardowns in a single test_suite");\
 	ASSERT_LABEL_DEFINED(assert_setup_method, "cannot declare teardown without a setup");\
-	decltype(assert_fixture)::teardown_function assert_teardown_method;\
+	::std::function<void(decltype(assert_fixture)::element_type::underlying_type&)> assert_teardown_method;\
 	goto ASSERT_GENERATE_LABEL(ASSERT_LABEL_BEGIN_TEARDOWN_BLOCK);\
 	while(true)\
 		if(true) {\
-			assert_fixture.set_teardown(assert_teardown_method);\
+			assert_fixture->set_teardown(assert_teardown_method);\
 			break;\
 		} else\
 			ASSERT_GENERATE_LABEL(ASSERT_LABEL_BEGIN_TEARDOWN_BLOCK):\
-				assert_teardown_method = [](decltype(assert_fixture)::fixture_type& fixture_label)
+				assert_teardown_method = [](decltype(assert_fixture)::element_type::underlying_type& fixture_label)
 
 
 namespace test {

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -14,17 +14,18 @@ tests {
 		};
 
 		test_case("fixtures behave as singletons when captured as constant references") {
-			const int* fixtureA = my_int_fixture;
-			const int* fixtureB = my_int_fixture;
+			const int* fixtureA = *my_int_fixture;
+			const int* fixtureB = *my_int_fixture;
 
 			assert(fixtureA, ==, fixtureB);
 		};
 
 		test_case("fixtures can be copied") {
 			// warning: each new copy implies new executions of setup and teardown
-			auto fixtureA = std::copy(my_int_fixture);
-			auto fixtureB = std::copy(my_int_fixture);
-			const int* non_copied_fixture = my_int_fixture;
+			using std::copy;
+			auto fixtureA = copy(*my_int_fixture);
+			auto fixtureB = copy(*my_int_fixture);
+			const int* non_copied_fixture = *my_int_fixture;
 
 			assert(fixtureA, !=, fixtureB);
 
@@ -42,20 +43,17 @@ tests {
 
 		teardown (fixture) {
 			fixture = "this fixture was torn down";
-			std::cerr << (std::string)fixture << std::endl;
 		};
 
 		test_case("fixtures are not deleted before all tests in the test suite finish") {
 			std::this_thread::sleep_for(1s);
-			assert((std::string)fixture, ==, "this fixture was setup");
+			assert((std::string)*fixture, ==, "this fixture was setup");
 		};
 
 		test_case("fixtures are correctly setup the first time") {
-			assert((std::string)fixture, ==, "this fixture was setup");
+			assert((std::string)*fixture, ==, "this fixture was setup");
 		};
-
 	}
-
 
 	test_suite("fixtures can be any user defined label") {
 		setup (int, another_fixture) {
@@ -64,7 +62,7 @@ tests {
 		};
 
 		test_case("fixtures behave as singletons when captured as constant references") {
-			int fixtureA = another_fixture;
+			int fixtureA = *another_fixture;
 
 			assert(fixtureA, ==, 10);
 		};
@@ -76,12 +74,12 @@ tests {
 		};
 
 		test_case("can be used in arithmetic expressions") {
-			auto six = three_fixture*2;
+			auto six = *three_fixture*2;
 			assert(six, ==, 6.0);
 		};
 
 		test_case("can be used in comparisons") {
-			assert(three_fixture, ==, 3.0);
+			assert(*three_fixture, ==, 3.0);
 		};
 	}
 }


### PR DESCRIPTION
Test suite setups were being executed once for each test case. This PR fixes that by sharing fixtures through a `shared_ptr` instead of doing weird things with copy constructors.